### PR TITLE
Export PanZoomOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panzoom-core",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Library for pan and zoom with possibility to moving, resizing and selecting elements inside",
   "main": "dist/main.umd.cjs",
   "module": "./dist/main.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import { PanZoomApi, PanZoomOptions } from './types';
 
-export { API } from './types';
+export { API, PanZoomOptions } from './types';
 
 export function getAllowedProps(): Array<keyof PanZoomOptions>;
 


### PR DESCRIPTION
It would be nice to be able to use panzoom options types. I use panzoom in angular app where I have quite strict typing rules and it would be very helpful in my and probably in others' case.
BTW thanks for creating awesome lib!